### PR TITLE
Fixed missing android dependency and update to 4.23

### DIFF
--- a/AppsFlyerSDK/Source/AppsFlyerSDK/AppsFlyerSDK.Build.cs
+++ b/AppsFlyerSDK/Source/AppsFlyerSDK/AppsFlyerSDK.Build.cs
@@ -18,38 +18,36 @@ public class AppsFlyerSDK : ModuleRules
 
 		PublicDependencyModuleNames.AddRange(new string[] { "Engine", "Core", "CoreUObject" });
 		PrivateIncludePathModuleNames.AddRange(new string[] { "Settings" });
+        
+        if (Target.Platform == UnrealTargetPlatform.IOS)
+        {
+                PublicAdditionalFrameworks.Add(
+                new Framework(
+                    "AppsFlyerLib",
+                    "../ThirdParty/iOS/AppsFlyerLib.embeddedframework.zip"
+                )
+            );
 
-		switch (Target.Platform)
-		{
-		case UnrealTargetPlatform.IOS:
-			PublicAdditionalFrameworks.Add(
-			    new UEBuildFramework(
-			        "AppsFlyerLib",
-			        "../ThirdParty/iOS/AppsFlyerLib.embeddedframework.zip"
-			    )
-			);
-
-			PublicFrameworks.AddRange(
-			    new string[]
-			{
-				"AdSupport",
-				"iAd",
-				"CoreTelephony",
-				"Security",
-				"SystemConfiguration",
-				"CFNetwork"
-			}
-			);
-			break;
-
-		case UnrealTargetPlatform.Android:
-			// Unreal Plugin Language
-			string PluginPath = Utils.MakePathRelativeTo(ModuleDirectory, Target.RelativeEnginePath);
-			AdditionalPropertiesForReceipt.Add("AndroidPlugin", System.IO.Path.Combine(PluginPath, "AppsFlyer_UPL.xml"));
-			// JNI
-			PublicIncludePathModuleNames.Add("Launch");
-			break;
-		}
+                PublicFrameworks.AddRange(
+                    new string[]
+                {
+                "AdSupport",
+                "iAd",
+                "CoreTelephony",
+                "Security",
+                "SystemConfiguration",
+                "CFNetwork"
+                }
+                );
+        }
+        else if (Target.Platform == UnrealTargetPlatform.Android)
+        {
+                // Unreal Plugin Language
+                string PluginPath = Utils.MakePathRelativeTo(ModuleDirectory, Target.RelativeEnginePath);
+                AdditionalPropertiesForReceipt.Add("AndroidPlugin", System.IO.Path.Combine(PluginPath, "AppsFlyer_UPL.xml"));
+                // JNI
+                PublicIncludePathModuleNames.Add("Launch");
+        }
 	}
 }
 }

--- a/AppsFlyerSDK/Source/AppsFlyerSDK/AppsFlyer_UPL.xml
+++ b/AppsFlyerSDK/Source/AppsFlyerSDK/AppsFlyer_UPL.xml
@@ -1,10 +1,11 @@
 <root xmlns:android="http://schemas.android.com/apk/res/android">
     <buildGradleAdditions>
         <insert>
-            dependencies {
-                implementation 'com.android.installreferrer:installreferrer:1.0'
-                implementation 'com.appsflyer:af-android-sdk:4.9.0'
-            }
+          dependencies {
+          implementation 'com.android.installreferrer:installreferrer:1.0'
+          implementation 'com.appsflyer:af-android-sdk:4.9.0'
+          implementation 'com.google.firebase:firebase-core:11.8.0'
+          }
         </insert>
     </buildGradleAdditions>
     <androidManifestUpdates>


### PR DESCRIPTION
- Added firebase implementation for android to prevent build error (related to #6). 

- Removed switch(Target.Platform) and replaced with if() {} else if() {}, because of next error:
`error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
`
- Replaced UEBuildFramework with Framework (UEBuildFramework name no longer in use since 4.22)
