### PR TITLE
Log ad revenue

### DIFF
--- a/AppsFlyerSDK/Source/AppsFlyerSDK/AppsFlyer_UPL_Android.xml
+++ b/AppsFlyerSDK/Source/AppsFlyerSDK/AppsFlyer_UPL_Android.xml
@@ -41,6 +41,14 @@
             import com.appsflyer.internal.platform_extension.PluginInfo;
             import java.util.HashMap;
             import java.util.Map;
+
+            import com.appsflyer.AFAdRevenueData;
+            import com.appsflyer.MediationNetwork;
+            import com.appsflyer.AppsFlyerLib;
+
+            import java.util.Currency;
+
+            import android.util.Log;
         </insert>
     </gameActivityImportAdditions>
     <gameActivityClassAdditions>
@@ -92,6 +100,27 @@
                 AppsFlyerLib.getInstance().disableAppSetId();
             }
 
+            public void afLogAdRevenue(
+                String monetizationNetwork,
+                int mediationNetwork,
+                double revenue,
+                String currency,
+                Map<String, String> customData)
+            {
+                AFAdRevenueData adRevenueData = new AFAdRevenueData(monetizationNetwork, getAFMediationNetwork(mediationNetwork), currency, revenue);
+    
+                Map<String, Object> additionalParameters = new HashMap<>();
+    
+                if(customData.containsKey("Country")) additionalParameters.put(AdRevenueScheme.COUNTRY, customData.get("Country"));
+                if(customData.containsKey("UnitID")) additionalParameters.put(AdRevenueScheme.AD_UNIT, customData.get("UnitID"));
+                if(customData.containsKey("AdType")) additionalParameters.put(AdRevenueScheme.AD_TYPE, customData.get("AdType"));
+                if(customData.containsKey("Placement")) additionalParameters.put(AdRevenueScheme.PLACEMENT, customData.get("Placement"));
+    
+                AppsFlyerLib.getInstance().logAdRevenue(adRevenueData, additionalParameters);
+    
+                Log.debug("AppsflyerLog Track ad revenue");
+            }
+
             // Deprecated
             public void afSetConsentData(boolean isGDPR, boolean hasConsentForDataUsage, boolean hasConsentForAdsPersonalization) {
                 AppsFlyerConsent consent;
@@ -116,6 +145,25 @@
                 );
 
                 AppsFlyerLib.getInstance().setConsentData(consent);
+            }
+
+            public MediationNetwork getAFMediationNetwork(int network){
+                switch (network) {
+                    case 0: return MediationNetwork.IRONSOURCE;
+                    case 1: return MediationNetwork.APPLOVIN_MAX;
+                    case 2: return MediationNetwork.GOOGLE_ADMOB;
+                    case 3: return MediationNetwork.FYBER;
+                    case 4: return MediationNetwork.APPODEAL;
+                    case 5: return MediationNetwork.ADMOST;
+                    case 6: return MediationNetwork.TOPON;
+                    case 7: return MediationNetwork.TRADPLUS;
+                    case 8: return MediationNetwork.YANDEX;
+                    case 9: return MediationNetwork.CHARTBOOST;
+                    case 10: return MediationNetwork.UNITY;
+                    case 11: return MediationNetwork.CUSTOM_MEDIATION;
+                    case 12: return MediationNetwork.DIRECT_MONETIZATION_NETWORK;
+                    default: return MediationNetwork.CUSTOM_MEDIATION;
+                }
             }
         </insert>
     </gameActivityClassAdditions>

--- a/AppsFlyerSDK/Source/AppsFlyerSDK/Public/AppsFlyerSDKBlueprint.h
+++ b/AppsFlyerSDK/Source/AppsFlyerSDK/Public/AppsFlyerSDKBlueprint.h
@@ -30,6 +30,24 @@ enum class EAFValidateAndLogStatus : uint8
     Error   UMETA(DisplayName = "Error")
 };
 
+UENUM(BlueprintType)
+enum class EAFMediationNetwork : uint8
+{
+	Ironsource					UMETA(DisplayName = "IronSource"),
+	Applovinmax					UMETA(DisplayName = "ApplovinMax"),
+	Googleadmob					UMETA(DisplayName = "GoogleAdmob"),
+	Fyber						UMETA(DisplayName = "Fyber"),
+	Appodeal					UMETA(DisplayName = "Appodeal"),
+	Admost						UMETA(DisplayName = "Admost"),
+	Topon						UMETA(DisplayName = "Topon"),
+	Tradplus					UMETA(DisplayName = "TradPlus"),
+	Yandex						UMETA(DisplayName = "Yandex"),
+	Chartboost					UMETA(DisplayName = "Chartboost"),
+	Unity						UMETA(DisplayName = "Unity"),
+	CustomMediation				UMETA(DisplayName = "Custom Mediation"),
+	DirectMonetizationNetwork	UMETA(DisplayName = "Direct Monetization Network")
+};
+
 USTRUCT(BlueprintType)
 struct FAFSDKPurchaseDetails
 {
@@ -136,6 +154,17 @@ class APPSFLYERSDK_API UAppsFlyerSDKBlueprint : public UBlueprintFunctionLibrary
 		TOptional<bool> HasConsentForAdsPersonalization,
 		TOptional<bool> HasConsentForAdStorage
 	);
+
+	/*!
+	* Log revenue from ads
+	* @param monetizationNetwork - Monetization network the ad was shown by, such as AdMob, UnityAds, Facebook e.t.c.
+	* @param mediationNetwork - Mediation network.
+	* @param revenue - Ad revenue (in millions)
+	* @param currency - Currency code
+	* @param extraData - Optional extra info for ad revenue. Can have "Country", "UnitID", "AdType" and "Placement" keys.
+	*/
+	UFUNCTION(BlueprintCallable, Category = AppsFlyerSDK, DisplayName = "AppsFlyerSDK log ad revenue")
+	static void logAdRevenue(FString monetizationNetwork, EAFMediationNetwork mediationNetwork, float revenue, FString currency, TMap <FString, FString> extraData);
 
 	/*!
 	 * Validates and logs an in-app purchase using the updated VAL V2 flow.


### PR DESCRIPTION
Log ad revenue feature implementation for Android and IOS

UAppsFlyerSDKBlueprint::logAdRevenue()
Available for both Blueprint and CPP.

Function parameters
- monetizationNetwork - Monetization network the ad was shown by, such as AdMob, UnityAds, Facebook e.t.c.
- mediationNetwork - Mediation network.
- revenue - Ad revenue (in millions)
- currency - Currency code
- extraData - Optional extra info for ad revenue. Can have "Country", "UnitID", "AdType" and "Placement" keys.

Tested on both platforms using UE4.27-plus. If there are any errors or issues, please, comment.